### PR TITLE
Update to @faremeter/types v0.17.0

### DIFF
--- a/packages/x-solana-settlement/package.json
+++ b/packages/x-solana-settlement/package.json
@@ -11,11 +11,6 @@
       "import": "./dist/src/index.js",
       "types": "./dist/src/index.d.ts"
     },
-    "./header": {
-      "require": "./dist/src/header.js",
-      "import": "./dist/src/header.js",
-      "types": "./dist/src/header.d.ts"
-    },
     "./facilitator": {
       "require": "./dist/src/facilitator.js",
       "import": "./dist/src/facilitator.js",

--- a/packages/x-solana-settlement/src/facilitator.ts
+++ b/packages/x-solana-settlement/src/facilitator.ts
@@ -1,12 +1,15 @@
 import { logger } from "./logger";
 import { type } from "arktype";
 import { Connection, Keypair, PublicKey } from "@solana/web3.js";
-import type { FacilitatorHandler } from "@faremeter/types/facilitator";
-import {
+import type {
+  FacilitatorHandler,
+  GetRequirementsArgs,
+} from "@faremeter/types/facilitator";
+import type {
   x402PaymentRequirements,
   x402PaymentPayload,
   x402SettleResponse,
-} from "@faremeter/types/x402";
+} from "@faremeter/types/x402v2";
 import { isValidationError, PaymentPayload } from "./types";
 
 import {
@@ -20,12 +23,12 @@ import {
 
 import * as ed from "@noble/ed25519";
 
-function errorResponse(msg: string): x402SettleResponse {
+function errorResponse(msg: string, network: string): x402SettleResponse {
   return {
     success: false,
-    error: msg,
-    txHash: null,
-    networkId: null,
+    errorReason: msg,
+    transaction: "",
+    network,
   };
 }
 
@@ -45,10 +48,10 @@ export const createFacilitatorHandler = (
   const asset = mint ? mint.toBase58() : "sol";
   const checkTupleAndAsset = checkTuple.and({ asset: `'${asset}'` });
 
-  const getRequirements = async (req: x402PaymentRequirements[]) => {
+  const getRequirements = async ({ accepts }: GetRequirementsArgs) => {
     const recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
 
-    return req
+    return accepts
       .filter((x) => !isValidationError(checkTupleAndAsset(x)))
       .map((x) => {
         return {
@@ -66,7 +69,7 @@ export const createFacilitatorHandler = (
     requirements: x402PaymentRequirements,
     payment: x402PaymentPayload,
   ) => {
-    const tupleMatches = checkTuple(payment);
+    const tupleMatches = checkTuple(payment.accepted);
 
     if (isValidationError(tupleMatches)) {
       return null;
@@ -75,7 +78,7 @@ export const createFacilitatorHandler = (
     const paymentPayload = PaymentPayload(payment.payload);
 
     if (isValidationError(paymentPayload)) {
-      return errorResponse(paymentPayload.summary);
+      return errorResponse(paymentPayload.summary, requirements.network);
     }
 
     const signature =
@@ -87,7 +90,7 @@ export const createFacilitatorHandler = (
         : paymentPayload.transactionSignature;
 
     if (!signature) {
-      return errorResponse("invalid signature");
+      return errorResponse("invalid signature", requirements.network);
     }
 
     logger.info(`Payment signature: ${signature}`);
@@ -95,19 +98,25 @@ export const createFacilitatorHandler = (
     const transaction = await getTransaction(connection, signature);
     if (!transaction) {
       logger.info("could not retrieve transaction");
-      return errorResponse("could not retrieve transaction");
+      return errorResponse(
+        "could not retrieve transaction",
+        requirements.network,
+      );
     }
 
     const isValidTx = await isValidTransferTransaction(transaction);
     if (!isValidTx) {
       logger.info("invalid transaction");
-      return errorResponse("invalid transaction");
+      return errorResponse("invalid transaction", requirements.network);
     }
 
     const transactionData = await extractTransferData(transaction);
     if (!transactionData.success) {
       logger.info("couldn't extract transfer data");
-      return errorResponse("could not extract transfer data");
+      return errorResponse(
+        "could not extract transfer data",
+        requirements.network,
+      );
     }
 
     const pubkey = await ed.getPublicKeyAsync(paymentPayload.sharedSecretKey);
@@ -119,15 +128,18 @@ export const createFacilitatorHandler = (
 
     if (!isValidMemoSignature) {
       logger.info("could not veify memo signature");
-      return errorResponse("could not verify memo signature");
+      return errorResponse(
+        "could not verify memo signature",
+        requirements.network,
+      );
     }
 
-    if (
-      Number(transactionData.data.amount) !==
-      Number(requirements.maxAmountRequired)
-    ) {
+    if (Number(transactionData.data.amount) !== Number(requirements.amount)) {
       logger.info("payments didn't match amount");
-      return errorResponse("payments didn't match amount");
+      return errorResponse(
+        "payments didn't match amount",
+        requirements.network,
+      );
     }
 
     const settleTx = await createSettleTransaction(
@@ -138,21 +150,24 @@ export const createFacilitatorHandler = (
     );
     if (!settleTx) {
       logger.info("couldn't create settle tx");
-      return errorResponse("couldn't create settlement tx");
+      return errorResponse(
+        "couldn't create settlement tx",
+        requirements.network,
+      );
     }
 
     const settleSig = await processTransaction(connection, settleTx);
 
     if (settleSig == null) {
       logger.info("couldn't process settlement");
-      return errorResponse("couldn't process settlement");
+      return errorResponse("couldn't process settlement", requirements.network);
     }
 
     return {
       success: true,
-      error: null,
-      txHash: settleSig,
-      networkId: payment.network,
+      transaction: settleSig,
+      network: requirements.network,
+      payer: paymentPayload.payer,
     };
   };
 

--- a/packages/x-solana-settlement/src/payment.ts
+++ b/packages/x-solana-settlement/src/payment.ts
@@ -7,7 +7,7 @@ import {
   TransactionInstruction,
   TransactionMessage,
 } from "@solana/web3.js";
-import type { x402PaymentRequirements } from "@faremeter/types/x402";
+import type { x402PaymentRequirements } from "@faremeter/types/x402v2";
 import type { RequestContext, PaymentExecer } from "@faremeter/types/client";
 
 import { PaymentRequirementsExtra, createPaymentPayload } from "./types";
@@ -94,7 +94,7 @@ export function createPaymentHandler(
         const exec = async () => {
           const paymentRequirements = {
             ...extra,
-            amount: Number(requirements.maxAmountRequired),
+            amount: Number(requirements.amount),
             receiver: new PublicKey(requirements.payTo),
             admin: new PublicKey(extra.admin),
           };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: 9.34.0
       version: 9.34.0
     '@faremeter/types':
-      specifier: 0.9.0
-      version: 0.9.0
+      specifier: 0.17.0
+      version: 0.17.0
     '@logtape/logtape':
       specifier: 1.0.4
       version: 1.0.4
@@ -106,7 +106,7 @@ importers:
         version: 0.31.1(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10)
       '@faremeter/types':
         specifier: 'catalog:'
-        version: 0.9.0
+        version: 0.17.0
       '@logtape/logtape':
         specifier: 'catalog:'
         version: 1.0.4
@@ -273,8 +273,8 @@ packages:
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@faremeter/types@0.9.0':
-    resolution: {integrity: sha512-/KbH4ILmTDzmIvmleGdy2nartQwD5WNFtYtBivKJnKsbegPzqZvCmBp61pFRzHnLxVp53FeROsFrW6HwBgh9vg==}
+  '@faremeter/types@0.17.0':
+    resolution: {integrity: sha512-Xq/k9++atY3u4JCVOmjRX/E355+cfY3jE+uSRjtANxSZ5LvOmPiEGjRPaN6CDHkVSgZTD6aK367GUCH6IuItew==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -2502,7 +2502,7 @@ snapshots:
       '@eslint/core': 0.15.2
       levn: 0.4.1
 
-  '@faremeter/types@0.9.0':
+  '@faremeter/types@0.17.0':
     dependencies:
       arktype: 2.1.21
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ packages:
 catalog:
   "@coral-xyz/anchor": 0.31.1
   "@eslint/js": 9.34.0
-  "@faremeter/types": 0.9.0
+  "@faremeter/types": 0.17.0
   "@hono/node-server": 1.19.1
   "@noble/ed25519": 2.3.0
   "@solana-program/compute-budget": 0.8.0


### PR DESCRIPTION
## Summary

- Remove broken `./header` export from package.json (referenced non-existent `src/header.ts`)
- Update `@faremeter/types` from v0.9.0 to v0.17.0, migrating to x402v2 types

## Changes

- `pnpm-workspace.yaml`: Bump `@faremeter/types` catalog version
- `packages/x-solana-settlement/src/facilitator.ts`: Switch to v2 imports, update `getRequirements` to accept `GetRequirementsArgs`, update `handleSettle` to use `payment.accepted`, rename response fields (`txHash`→`transaction`, `networkId`→`network`, `error`→`errorReason`), add `payer` to success response
- `packages/x-solana-settlement/src/payment.ts`: Switch to v2 imports, change `maxAmountRequired` to `amount`
- `packages/x-solana-settlement/package.json`: Remove broken header export

## Testing

- `make all` passes (lint, build, test)

Closes FMTR-301